### PR TITLE
Added more nginx commands, since my server needed a 'nginx:start'

### DIFF
--- a/lib/capistrano/tasks/nginx.rake
+++ b/lib/capistrano/tasks/nginx.rake
@@ -62,10 +62,16 @@ namespace :nginx do
     end
   end
 
-  desc 'Reload nginx configuration'
-  task :reload do
-    on roles :web do
-      sudo nginx_service_path, 'reload'
+  # will generate all commands that nginx supports, for instance:
+  # cap ENV nginx:start
+  # cap ENV nginx:reload
+  # cap ENV nginx:configtest
+  %w(start stop reload configtest status force-reload upgrade restart reopen_logs).each do |tsk|
+    desc %('#{tsk.capitalize}' nginx command)
+    task tsk do
+      on roles :web do
+        sudo nginx_service_path, tsk
+      end
     end
   end
 


### PR DESCRIPTION
The following commands are now available for nginx:

```
cap ENV nginx:start
cap ENV nginx:stop
cap ENV nginx:reload
cap ENV nginx:configtest
cap ENV nginx:status
cap ENV nginx:force-reload
cap ENV nginx:upgrade
cap ENV nginx:restart
cap ENV nginx:reopen_logs
```
