### PR TITLE
Fix that unicorn:upgrade sometimes fails the cap deploy script

### DIFF
--- a/lib/capistrano/tasks/unicorn.rake
+++ b/lib/capistrano/tasks/unicorn.rake
@@ -73,11 +73,10 @@ namespace :unicorn do
 
   before :setup_initializer, :defaults
   before :setup_logrotate, :defaults
-
 end
 
 namespace :deploy do
-  after :publishing, 'unicorn:upgrade'
+  after :publishing, 'unicorn:restart'
 end
 
 desc 'Server setup tasks'


### PR DESCRIPTION
Still, use unicorn:reload after deployment.

If you, like me, have problems, then this workaround could be used:

my `config/deploy.rb`:

```
namespace :deploy do
  after :publishing, 'unicorn:stop'
  after :publishing, 'unicorn:start'
end

```

This commit is essentially a revert of https://github.com/jesperronn/capistrano-unicorn-nginx-ami/pull/2

(commit 5e96fdbc0f2d03f6f85ed6b694c211257925b056 )

so that unicorn:reload is used, but unicorn:upgrade still exists.

Best would be if someone can help to fix the `unicorn:upgrade` return code so
that capistrano doesn't fail
