### PR TITLE
Possible to override default restart strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,40 @@ This means that some commands are different:
 
 * using `chkconfig` instead of update-rc.d
 * assuming `nginx` is installed and available at `/etc/nginx`
-* assuming configuration for nginx lives at `/etc/conf.d/[ENV_NAME].conf
+* assuming configuration for nginx lives at `/etc/conf.d/[ENV_NAME].conf`
 
 All credit to irlrobot.
+
+# NOTE: This fork has different version numbers!
+
+Since I made this fork, in order to use the release pages on github, I decided
+to move forward and put new version numbers.
+
+So beware that version numbers differ from v4.0.0 and onwards.
+
+# unicorn:restart vs unicorn:upgrade
+
+For backwards compatibility, this plugin will run `sudo service unicorn restart`,
+which reloads processes but doesn't pick up code changes.
+
+Typically you would want to use `unicorn:upgrade` instead (picks up code changes).
+
+put the following snippet in your `deploy.rb`:
+
+```
+# clear originating task before replacing it
+Rake::Task['unicorn:restart_command'].clear_actions
+namespace :unicorn do
+  task :restart_command do
+    invoke 'unicorn:upgrade'
+  end
+end
+```
+
+
+
+-----
+
 
 # Capistrano::UnicornNginx
 

--- a/lib/capistrano/tasks/unicorn.rake
+++ b/lib/capistrano/tasks/unicorn.rake
@@ -62,21 +62,28 @@ namespace :unicorn do
 
   %w(start stop restart upgrade).each do |command|
     desc "#{command} unicorn"
+    desc "run unicorn #{command} command"
     task command do
       on roles :app do
         sudo 'service', fetch(:unicorn_service), command
-        # for some reason i kept getting command not found here
-        # `sudo service #{fetch(:unicorn_service)} #{command}`
       end
     end
   end
 
   before :setup_initializer, :defaults
   before :setup_logrotate, :defaults
+
+  # overridable command for restarting the unicorn proces. Typically
+  # you would want to use `unicorn:upgrade` instead (picks up code changes).
+  #
+  # See example for overriding in the README
+  task :restart_command do
+    invoke 'unicorn:restart'
+  end
 end
 
 namespace :deploy do
-  after :publishing, 'unicorn:restart'
+  after :publishing, 'unicorn:restart_command'
 end
 
 desc 'Server setup tasks'


### PR DESCRIPTION
Since unicorn:upgrade should be preferred as it picks up code changes

Example: put the following snippet in your `deploy.rb`:

```
 # clear originating task before replacing it
 Rake::Task['unicorn:restart_command'].clear_actions
 namespace :unicorn do
   task :restart_command do
     invoke 'unicorn:upgrade'
   end
 end
```
